### PR TITLE
Cocos like dataset in range

### DIFF
--- a/src/data/get_coco.py
+++ b/src/data/get_coco.py
@@ -2,6 +2,8 @@
 from torchvision.datasets import CocoCaptions
 from torchvision import transforms
 from open_clip import create_model_from_pretrained
+from torch.utils.data import Subset
+
 model_id = "hf-hub:apple/DFN5B-CLIP-ViT-H-14-384"
 
 _, clip_processor = create_model_from_pretrained(model_id)
@@ -15,9 +17,16 @@ target_size = {"Llava": (336,336),
 img_transformer = lambda model_n : transforms.Compose([transforms.Resize(target_size[model_n]),
                                                        transforms.ToTensor()])
 def get_cocos_like_dataset(img_transform, text_tokenize, captions_per_img,
-                           img_root=coco_root, ann_root=coco_ann_file):
+                           img_root=coco_root, ann_root=coco_ann_file, option = "all"):
     if text_tokenize is None:
-        target_transform = lambda texts : texts[:captions_per_img]
+        if option == "all":
+            target_transform = lambda texts : texts[:captions_per_img]
+        elif option == "first":
+            target_transform = lambda texts : texts[0]
+        elif option == "concat":
+            target_transform = lambda texts : [" ".join(texts)]
+        else:
+            raise ValueError("option should be either all, first or concat")
     else:
         target_transform = lambda texts :text_tokenize(texts[:captions_per_img])
     if img_transform is None:
@@ -37,7 +46,6 @@ def load_cocos_like_dataset(captions_per_img, model_name, img_root = None, ann_r
         img_root = coco_root
     if ann_root is None:
         ann_root = coco_ann_file
-    img_transform = None
     img_transform = get_image_pretransformer(model_name)
     return get_cocos_like_dataset(img_transform, None, captions_per_img, img_root, ann_root)
 
@@ -46,3 +54,15 @@ def get_image_pretransformer(model_name):
         return clip_processor
     else:
         return img_transformer(model_name)
+  
+def load_cocos_like_dataset_in_range(captions_per_img, model_name, img_root = None, ann_root = None, option = "all", start_index = 0, last_index = 500):
+    if img_root is None:
+        img_root = coco_root
+    if ann_root is None:
+        ann_root = coco_ann_file
+    img_transform = get_image_pretransformer(model_name)
+    dataset = get_cocos_like_dataset(img_transform, None, captions_per_img, img_root, ann_root, option = option)
+    return Subset(dataset, list(range(start_index, last_index)))
+
+
+


### PR DESCRIPTION
You can get COCO and nocaps datasets in a range with the default being the first 500. Additionally, you can choose whether you want the first, all, or a concatenation of captions per image.