### PR TITLE
Visual Genome data reader

### DIFF
--- a/src/data/visual_genome.py
+++ b/src/data/visual_genome.py
@@ -1,0 +1,92 @@
+import os
+import json
+import urllib.request
+import zipfile
+import sys
+sys.path.append("../")
+from services.settings import settings
+
+class VisualGenomeDataset:
+    def __init__(self, data_dir,size):
+        self.data_dir = data_dir
+        self.size = size
+        #paths
+        self.object_zip_file_path = os.path.join(data_dir, 'objects.json.zip')
+        self.object_json_file_path = os.path.join(data_dir, 'objects.json')
+        self.metadata_zip_file_path = os.path.join(data_dir, 'image_data.json.zip')
+        self.metadata_json_file_path = os.path.join(data_dir, 'image_data.json')
+        # create / download / load necessary data
+        self.init_data()
+        
+    def init_data(self):
+        # Ensure the data directory exists
+        if not os.path.exists(self.data_dir):
+            os.makedirs(self.data_dir)
+            
+        # Download and unzip the object file if not present
+        if not os.path.exists(self.object_json_file_path):
+            self._download_objects()
+            
+        # Load the object json data
+        with open(self.object_json_file_path, 'r') as file:
+            print("Loading object data...")
+            self.object_data = json.load(file)
+                
+        # Download and unzip metadata if not present
+        if not os.path.exists(self.metadata_json_file_path):
+            self._download_metadata()
+                
+        # Load the metadata json data
+        with open(self.metadata_json_file_path, 'r') as file:
+            print("Loading metadata...")
+            self.metadata = json.load(file)
+
+    def _download_objects(self):
+        url = "https://homes.cs.washington.edu/~ranjay/visualgenome/data/dataset/objects.json.zip"
+        print("Downloading object json...")
+        urllib.request.urlretrieve(url, self.object_zip_file_path)
+        
+        print("Unzipping object json...")
+        with zipfile.ZipFile(self.object_zip_file_path, 'r') as zip_ref:
+            zip_ref.extractall(self.data_dir)
+        print("Removing the zip file...")
+        os.remove(self.object_zip_file_path)
+        
+    def _download_metadata(self):
+        url = "https://homes.cs.washington.edu/~ranjay/visualgenome/data/dataset/image_data.json.zip"
+        print("Downloading metadata...")
+        urllib.request.urlretrieve(url,self.metadata_zip_file_path)
+        
+        print("Unzipping metadata...")
+        with zipfile.ZipFile(self.metadata_zip_file_path, 'r') as zip_ref:
+            zip_ref.extractall(self.data_dir)
+        print("Removing the zip file...")
+        os.remove(self.metadata_zip_file_path)
+        
+    def get_image_url_from_id(self, image_id):
+        return self.metadata[image_id - 1]['url'] 
+            
+    def get_filenames_and_objects(self):
+        result = {}
+        for entry in self.object_data[:self.size]:
+            image_url = self.get_image_url_from_id(entry['image_id'])
+            objects = [obj['names'][0] for obj in entry['objects']]
+            result[image_url] = list(set(objects))
+        return result
+    
+    def save_filenames_and_objects(self, filename):
+        with open(filename, 'w') as file:
+            json.dump(self.get_filenames_and_objects(), file, indent=4)
+
+# Example usage
+data_dir = os.path.join(settings.data_dir, 'visual_genome')
+
+vg_dataset = VisualGenomeDataset(data_dir, size=1000) # size = no. of images to load
+filenames_and_objects = vg_dataset.get_filenames_and_objects()
+vg_dataset.save_filenames_and_objects(os.path.join(data_dir, 'filenames_and_objects.json'))
+
+# Print a few examples
+for image_id, objects in list(filenames_and_objects.items())[:3]:
+    print(f"Image URL: {image_id}")
+    print(f"Objects: {objects}")
+    print("-----")


### PR DESCRIPTION
I pushed a simple script that saves a dictionary in a json file with the Visual Genome image url as key and the objects in the image as a list in the value.

You don't need to prepare or download anything related to Visual Genome, the script will check the folder data/visual_genome and create, download, unzip necessary files.

Simply run `python visual_genome.py` and as an output of the example usage I added under the class definition you should see few examples like: 

Image URL: https://cs.stanford.edu/people/rak248/VG_100K_2/1.jpg
Objects: ['parking meter', 'trees', 'clock', 'wall', 'chin', 'lamp post', 'sidewalk', 'headlight', 'street', 'shoes', 'sign', 'bike', 'pants', 'jacket', 'back', 'building', 'shirt', 'arm', 'shade', 'car', 'van', 'glasses', 'tree trunk', 'windows', 'man', 'tree']

Image URL: https://cs.stanford.edu/people/rak248/VG_100K/2.jpg
Objects: ['sidewalk', 'road', 'pole', 'car', 'backpack', 'crosswalk', 'lights', 'window', 'walk sign', 'street light', 'sneakers', 'man', 'sign', 'building', 'bike', 'tree']

Image URL: https://cs.stanford.edu/people/rak248/VG_100K/3.jpg
Objects: ['wireless phone', 'picture', 'cubicles', 'monitor', 'white top', 'pen', 'wall', 'computer tower', 'strap', 'pluged', 'outlet', 'hair', 'desk', 'mouse', 'keyboard', 'dividing screen', 'telephone', 'plug', 'floor', 'bag', 'desktop', 'photos', 'chain', 'cables', 'drawer', 'computer case', 'cable', 'computer', 'girl', 'filing cabinet', 'table', 'handle']

And under the data/visual_genome folder, 3 files will be created: 
- filenames_and_objects.json
- image_data.json
- objects.json

We can later adjust the size but for now I set it to 1000.