### PR TITLE
GiT eval notebooks for aggregation and all-embeddings methods

### DIFF
--- a/src/gi2t/coco_experiment_all.ipynb
+++ b/src/gi2t/coco_experiment_all.ipynb
@@ -1,0 +1,270 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../\")\n",
+    "from pycocotools.coco import COCO\n",
+    "from sentence_transformers import SentenceTransformer\n",
+    "from sklearn.metrics.pairwise import cosine_similarity\n",
+    "from eval.metrics import Metrics\n",
+    "import json\n",
+    "import os\n",
+    "import random\n",
+    "from services.settings import settings\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/prakt/s0077/miniconda3/envs/image-search/lib/python3.11/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set parameters\n",
+    "k = 10\n",
+    "threshold = 0.3\n",
+    "last_index = 500\n",
+    "\n",
+    "options_with_all = [\"avg_embed\", \"highest_singular_score\",\"avg_score\"]\n",
+    "\n",
+    "all_queries_path = os.path.join(settings.project_root_dir,\"src/eval/extended_queries.json\" )\n",
+    "all_queries = json.load(open(all_queries_path))\n",
+    "response_dict_path = os.path.join(settings.output_dir, \"response_dict_git_500.json\")\n",
+    "\n",
+    "encoder_model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')\n",
+    "url_prefix=\"http://images.cocodataset.org/val2017/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loading annotations into memory...\n",
+      "Done (t=0.03s)\n",
+      "creating index...\n",
+      "index created!\n"
+     ]
+    }
+   ],
+   "source": [
+    "def set_coco_object(data_dir):\n",
+    "    ann_file = os.path.join(data_dir, 'annotations/captions_val2017.json')\n",
+    "    coco = COCO(ann_file)\n",
+    "    return coco\n",
+    "\n",
+    "def embed_text(text,embedder):\n",
+    "    return embedder.encode([text])\n",
+    "\n",
+    "def get_image_urls(img_ids, coco):\n",
+    "    img_urls = []\n",
+    "    for img_id in img_ids:\n",
+    "        img = coco.loadImgs(img_id)[0]\n",
+    "        img_urls.append(img['coco_url'])\n",
+    "    return img_urls\n",
+    "\n",
+    "def get_coco_image_captions(coco, image_id):\n",
+    "    annIds = coco.getAnnIds(imgIds=image_id)\n",
+    "    anns = coco.loadAnns(annIds)\n",
+    "    captions = [ann['caption'] for ann in anns]\n",
+    "    return captions\n",
+    "\n",
+    "def fetch_image(url):\n",
+    "    image = Image.open(requests.get(url, stream=True).raw)\n",
+    "    return image\n",
+    "\n",
+    "def show_images(img_urls):\n",
+    "    fig, axs = plt.subplots(1, len(img_urls), figsize=(20, 20))\n",
+    "    for i, url in enumerate(img_urls):\n",
+    "        img = fetch_image(url)\n",
+    "        axs[i].imshow(img)\n",
+    "        axs[i].axis('off')\n",
+    "    plt.show()\n",
+    "\n",
+    "embedder = SentenceTransformer('all-MiniLM-L6-v2')\n",
+    "coco = set_coco_object(os.path.join(settings.data_dir, 'coco-images'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Metric related functions\n",
+    "def get_scores(retrieved_files, gt_retrieved_files, performance_dict):\n",
+    "    performance_dict[\"precision\"].append(Metrics.precision(retrieved_files, gt_retrieved_files))\n",
+    "    performance_dict[\"recall\"].append(Metrics.recall(retrieved_files, gt_retrieved_files))\n",
+    "    performance_dict[\"f1\"].append(Metrics.f1_score(retrieved_files, gt_retrieved_files))\n",
+    "    performance_dict[\"nDCG\"].append(Metrics.ndcg(retrieved_files, gt_retrieved_files, 5))\n",
+    "    return performance_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def search(query, K, SIZE,performance_dict, avg_embed_sim=False, highest_singular_sim=False, highest_avg_sim=False):\n",
+    "    query_embedding = embed_text(query, embedder)\n",
+    "    # this loads from a file i saved while creating embeddings\n",
+    "    # but taking the first 500 id from coco object would be the same\n",
+    "    # or i can also share the ids for the images\n",
+    "    img_ids = [int(line.strip()) for line in open('../../data/coco_embeddings/coco_image_ids_' + str(SIZE) +'.txt')]\n",
+    "    \n",
+    "    # load GIT embeddings and calculate similarities with the query embedding, then get top K images\n",
+    "    git_embeddings = np.load('../../data/git_embeddings/git_caption_embeddings_' + str(SIZE) +'.npy')\n",
+    "    git_similarity_scores = cosine_similarity(query_embedding, git_embeddings).flatten()\n",
+    "    git_topk = np.argsort(git_similarity_scores)[::-1][:K]\n",
+    "    \n",
+    "    # 1st option: needs averaged embeddings\n",
+    "    if avg_embed_sim:\n",
+    "        ground_truth_embeddings = np.load('../../data/coco_embeddings/coco_embeddings_' + str(SIZE) +'_averaged.npy')\n",
+    "        ground_truth_similarity_scores= cosine_similarity(query_embedding, ground_truth_embeddings).flatten()\n",
+    "    # other 2 options: needs individual embeddings    \n",
+    "    else:\n",
+    "        ground_truth_embeddings = np.load('../../data/coco_embeddings/coco_embeddings_' + str(SIZE) +'.npy') # (SIZE, 5, 384)\n",
+    "        ground_truth_similarity_scores = []\n",
+    "        for caption_embeddings_per_image in ground_truth_embeddings:\n",
+    "            sim_scores = cosine_similarity(query_embedding, caption_embeddings_per_image).flatten()\n",
+    "            if highest_singular_sim:\n",
+    "                # get the highest similarity score per image\n",
+    "                singular_sim = np.max(sim_scores)\n",
+    "                ground_truth_similarity_scores.append(singular_sim)\n",
+    "            elif highest_avg_sim:\n",
+    "                # get the average similarity score per image\n",
+    "                avg_sim = np.mean(sim_scores)\n",
+    "                ground_truth_similarity_scores.append(avg_sim)\n",
+    "            \n",
+    "\n",
+    "    # Get top K images from ground truth (argsort returns indexes)\n",
+    "    ground_truth_topk = np.argsort(ground_truth_similarity_scores)[::-1][:K]\n",
+    "   \n",
+    "    # Get image ids according to indexes\n",
+    "    ground_truth_img_ids = [img_ids[i] for i in ground_truth_topk]\n",
+    "    git_img_ids = [img_ids[i] for i in git_topk]\n",
+    "\n",
+    "    # Get image urls\n",
+    "    ground_truth_img_urls = get_image_urls(ground_truth_img_ids, coco)\n",
+    "    git_img_urls = get_image_urls(git_img_ids, coco)\n",
+    "   \n",
+    "    performance_dict = get_scores(git_img_ids, ground_truth_img_ids, performance_dict)\n",
+    "    \n",
+    "    return performance_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Option avg_embed\n",
+      "avg_embed object\n",
+      "{'precision': 0.56, 'recall': 0.56, 'f1': 0.56, 'nDCG': 0.743}\n",
+      "avg_embed action\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'precision': 0.54, 'recall': 0.54, 'f1': 0.54, 'nDCG': 0.828}\n",
+      "avg_embed objects_with_count\n",
+      "{'precision': 0.48, 'recall': 0.48, 'f1': 0.48, 'nDCG': 0.658}\n",
+      "avg_embed reasoning\n",
+      "{'precision': 0.52, 'recall': 0.52, 'f1': 0.52, 'nDCG': 0.745}\n",
+      "avg_embed text_on_image\n",
+      "{'precision': 0.62, 'recall': 0.62, 'f1': 0.62, 'nDCG': 0.746}\n",
+      "Option highest_singular_score\n",
+      "highest_singular_score object\n",
+      "{'precision': 0.46, 'recall': 0.46, 'f1': 0.46, 'nDCG': 0.859}\n",
+      "highest_singular_score action\n",
+      "{'precision': 0.44, 'recall': 0.44, 'f1': 0.44, 'nDCG': 0.83}\n",
+      "highest_singular_score objects_with_count\n",
+      "{'precision': 0.4, 'recall': 0.4, 'f1': 0.4, 'nDCG': 0.702}\n",
+      "highest_singular_score reasoning\n",
+      "{'precision': 0.42, 'recall': 0.42, 'f1': 0.42, 'nDCG': 0.667}\n",
+      "highest_singular_score text_on_image\n",
+      "{'precision': 0.54, 'recall': 0.54, 'f1': 0.54, 'nDCG': 0.721}\n",
+      "Option avg_score\n",
+      "avg_score object\n",
+      "{'precision': 0.54, 'recall': 0.54, 'f1': 0.54, 'nDCG': 0.549}\n",
+      "avg_score action\n",
+      "{'precision': 0.56, 'recall': 0.56, 'f1': 0.56, 'nDCG': 0.828}\n",
+      "avg_score objects_with_count\n",
+      "{'precision': 0.48, 'recall': 0.48, 'f1': 0.48, 'nDCG': 0.701}\n",
+      "avg_score reasoning\n",
+      "{'precision': 0.46, 'recall': 0.46, 'f1': 0.46, 'nDCG': 0.749}\n",
+      "avg_score text_on_image\n",
+      "{'precision': 0.62, 'recall': 0.62, 'f1': 0.62, 'nDCG': 0.738}\n"
+     ]
+    }
+   ],
+   "source": [
+    "for option in options_with_all:\n",
+    "    print(\"Option\", option)\n",
+    "    for category in all_queries[\"categories\"].keys():\n",
+    "        print(option, category)\n",
+    "        query_group = all_queries[\"categories\"][category]\n",
+    "        performance_dict = {\"precision\": [], \"recall\": [], \"f1\": [], \"nDCG\": []}\n",
+    "        for query in query_group:\n",
+    "            if option == \"avg_embed\":\n",
+    "                \n",
+    "                performance_dict = search(query=query, K=10, SIZE=500,performance_dict=performance_dict, avg_embed_sim=True)\n",
+    "            elif option == \"highest_singular_score\":\n",
+    "                performance_dict = search(query=query, K=10, SIZE=500,performance_dict=performance_dict,  highest_singular_sim=True)            \n",
+    "            else: # avg_score    \n",
+    "                performance_dict = search(query=query, K=10, SIZE=500,performance_dict=performance_dict,  highest_avg_sim=True)\n",
+    "                          \n",
+    "        avg_performance_dict = {k: sum(v) / len(v) for k, v in performance_dict.items()}\n",
+    "        # round all values to 3 decimal places\n",
+    "        avg_performance_dict = {k: round(v, 3) for k, v in avg_performance_dict.items()}\n",
+    "        print(avg_performance_dict)   "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "image-search",
+   "language": "python",
+   "name": "image-search"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/gi2t/coco_experiment_index.ipynb
+++ b/src/gi2t/coco_experiment_index.ipynb
@@ -1,0 +1,411 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/prakt/s0077/miniconda3/envs/image-search/lib/python3.11/site-packages/sentence_transformers/cross_encoder/CrossEncoder.py:11: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "  from tqdm.autonotebook import tqdm, trange\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../\")\n",
+    "from pycocotools.coco import COCO\n",
+    "from sentence_transformers import SentenceTransformer\n",
+    "from services.search import ImageRepresentations, SearchService\n",
+    "from eval.metrics import Metrics\n",
+    "import json\n",
+    "import os\n",
+    "import random\n",
+    "from services.settings import settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/prakt/s0077/miniconda3/envs/image-search/lib/python3.11/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set parameters\n",
+    "k = 10\n",
+    "threshold = 0.3\n",
+    "last_index = 500\n",
+    "\n",
+    "options_without_all = [\"first\", \"concat\",\"random\"]\n",
+    "\n",
+    "all_queries_path = os.path.join(settings.project_root_dir,\"src/eval/extended_queries.json\" )\n",
+    "all_queries = json.load(open(all_queries_path))\n",
+    "response_dict_path = os.path.join(settings.output_dir, \"response_dict_\" + str(last_index) +\".json\")\n",
+    "\n",
+    "encoder_model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')\n",
+    "url_prefix=\"http://images.cocodataset.org/val2017/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['birthday cake',\n",
+       " 'wooden chair',\n",
+       " 'antique pocket watch',\n",
+       " 'crystal wine glasses',\n",
+       " 'vintage sofa']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all_queries[\"categories\"][\"object\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loading annotations into memory...\n",
+      "Done (t=0.03s)\n",
+      "creating index...\n",
+      "index created!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# COCO RELATED FUNCTIONS\n",
+    "def set_coco_object(data_dir):\n",
+    "    ann_file = os.path.join(data_dir, 'coco-images/annotations/captions_val2017.json')\n",
+    "    coco = COCO(ann_file)\n",
+    "    return coco\n",
+    "\n",
+    "def get_coco_ids_from_filenames(coco, filename_list):\n",
+    "    # drop the .jpg and convert to int\n",
+    "    filename_list = [int(filename[:-4]) for filename in filename_list]\n",
+    "    return filename_list\n",
+    "    \n",
+    "def get_coco_captions_by_index(coco, image_id):\n",
+    "    annIds = coco.getAnnIds(imgIds=image_id)\n",
+    "    anns = coco.loadAnns(annIds)\n",
+    "    captions = [ann['caption'] for ann in anns]\n",
+    "    return captions\n",
+    "\n",
+    "def aggregate_captions(captions,mode):\n",
+    "    if mode == \"first\":\n",
+    "        return captions[0]\n",
+    "    elif mode == \"concat\":\n",
+    "        return \" \".join(captions)\n",
+    "    elif mode == \"random\":\n",
+    "        return random.choice(captions)\n",
+    "    else:\n",
+    "        raise ValueError(\"Invalid mode\")\n",
+    "\n",
+    "def get_aggregated_caption_list(coco, mode, filenames):\n",
+    "    ids = get_coco_ids_from_filenames(coco, filenames)\n",
+    "    aggregated_caption_list = []\n",
+    "    for i in ids:\n",
+    "        captions = get_coco_captions_by_index(coco, i)\n",
+    "        aggregated_caption_list.append(aggregate_captions(captions, mode))\n",
+    "    return aggregated_caption_list\n",
+    "\n",
+    "# set coco object\n",
+    "coco_object = set_coco_object(settings.data_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Metric related functions\n",
+    "def get_scores(retrieved_files, gt_retrieved_files, performance_dict):\n",
+    "    performance_dict[\"precision\"].append(Metrics.precision(retrieved_files, gt_retrieved_files))\n",
+    "    performance_dict[\"recall\"].append(Metrics.recall(retrieved_files, gt_retrieved_files))\n",
+    "    performance_dict[\"f1\"].append(Metrics.f1_score(retrieved_files, gt_retrieved_files))\n",
+    "    performance_dict[\"nDCG\"].append(Metrics.ndcg(retrieved_files, gt_retrieved_files, 5))\n",
+    "    performance_dict[\"mRR\"].append(Metrics.mrr(retrieved_files, gt_retrieved_files))\n",
+    "    return performance_dict\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: '/usr/prakt/s0077/vlm-based-image-search/outputs/response_dict_500.json'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[6], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# set git's search service\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m git_predicted_file \u001b[38;5;241m=\u001b[39m json\u001b[38;5;241m.\u001b[39mload(\u001b[38;5;28mopen\u001b[39m(response_dict_path))\n\u001b[1;32m      3\u001b[0m filenames \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlist\u001b[39m(git_predicted_file\u001b[38;5;241m.\u001b[39mkeys())\n\u001b[1;32m      4\u001b[0m git_image_representions \u001b[38;5;241m=\u001b[39m ImageRepresentations(filenames\u001b[38;5;241m=\u001b[39mfilenames,\n\u001b[1;32m      5\u001b[0m                                                representations\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mlist\u001b[39m(git_predicted_file\u001b[38;5;241m.\u001b[39mvalues()), \n\u001b[1;32m      6\u001b[0m                                                url_prefix\u001b[38;5;241m=\u001b[39murl_prefix)\n",
+      "File \u001b[0;32m~/miniconda3/envs/image-search/lib/python3.11/site-packages/IPython/core/interactiveshell.py:310\u001b[0m, in \u001b[0;36m_modified_open\u001b[0;34m(file, *args, **kwargs)\u001b[0m\n\u001b[1;32m    303\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m file \u001b[38;5;129;01min\u001b[39;00m {\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m}:\n\u001b[1;32m    304\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[1;32m    305\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mIPython won\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mt let you open fd=\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mfile\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m by default \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    306\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mas it is likely to crash IPython. If you know what you are doing, \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    307\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124myou can use builtins\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m open.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    308\u001b[0m     )\n\u001b[0;32m--> 310\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m io_open(file, \u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '/usr/prakt/s0077/vlm-based-image-search/outputs/response_dict_500.json'"
+     ]
+    }
+   ],
+   "source": [
+    "# set git's search service\n",
+    "git_predicted_file = json.load(open(response_dict_path))\n",
+    "filenames = list(git_predicted_file.keys())\n",
+    "git_image_representions = ImageRepresentations(filenames=filenames,\n",
+    "                                               representations=list(git_predicted_file.values()), \n",
+    "                                               url_prefix=url_prefix)\n",
+    "\n",
+    "git_ss_k = SearchService(image_representations=git_image_representions, encoder_model=encoder_model, k=10)\n",
+    "git_ss_thresh = SearchService(image_representations=git_image_representions, encoder_model=encoder_model, threshold=0.3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index created with 500 sentences\n",
+      "Index created with 500 sentences\n",
+      "Option first\n",
+      "Category: object, Method: k=10\n",
+      "{'precision': 0.48, 'recall': 0.48, 'f1': 0.48, 'nDCG': 0.566, 'mRR': 1.0}\n",
+      "Category: object, Method: threshold=0.3\n",
+      "{'precision': 0.455, 'recall': 0.457, 'f1': 0.45, 'nDCG': 0.746, 'mRR': 0.961}\n",
+      "Category: action, Method: k=10\n",
+      "{'precision': 0.46, 'recall': 0.46, 'f1': 0.46, 'nDCG': 0.858, 'mRR': 1.0}\n",
+      "Category: action, Method: threshold=0.3\n",
+      "{'precision': 0.518, 'recall': 0.442, 'f1': 0.467, 'nDCG': 0.891, 'mRR': 0.983}\n",
+      "Category: objects_with_count, Method: k=10\n",
+      "{'precision': 0.34, 'recall': 0.34, 'f1': 0.34, 'nDCG': 0.713, 'mRR': 1.0}\n",
+      "Category: objects_with_count, Method: threshold=0.3\n",
+      "{'precision': 0.346, 'recall': 0.326, 'f1': 0.334, 'nDCG': 0.619, 'mRR': 0.879}\n",
+      "Category: reasoning, Method: k=10\n",
+      "{'precision': 0.34, 'recall': 0.34, 'f1': 0.34, 'nDCG': 0.664, 'mRR': 1.0}\n",
+      "Category: reasoning, Method: threshold=0.3\n",
+      "{'precision': 0.324, 'recall': 0.291, 'f1': 0.302, 'nDCG': 0.546, 'mRR': 0.786}\n",
+      "Category: text_on_image, Method: k=10\n",
+      "{'precision': 0.5, 'recall': 0.5, 'f1': 0.5, 'nDCG': 0.573, 'mRR': 1.0}\n",
+      "Category: text_on_image, Method: threshold=0.3\n",
+      "{'precision': 0.412, 'recall': 0.48, 'f1': 0.439, 'nDCG': 0.525, 'mRR': 0.767}\n",
+      "Index created with 500 sentences\n",
+      "Index created with 500 sentences\n",
+      "Option concat\n",
+      "Category: object, Method: k=10\n",
+      "{'precision': 0.5, 'recall': 0.5, 'f1': 0.5, 'nDCG': 0.778, 'mRR': 1.0}\n",
+      "Category: object, Method: threshold=0.3\n",
+      "{'precision': 0.441, 'recall': 0.522, 'f1': 0.469, 'nDCG': 0.774, 'mRR': 0.827}\n",
+      "Category: action, Method: k=10\n",
+      "{'precision': 0.46, 'recall': 0.46, 'f1': 0.46, 'nDCG': 0.877, 'mRR': 1.0}\n",
+      "Category: action, Method: threshold=0.3\n",
+      "{'precision': 0.532, 'recall': 0.443, 'f1': 0.475, 'nDCG': 0.884, 'mRR': 0.983}\n",
+      "Category: objects_with_count, Method: k=10\n",
+      "{'precision': 0.3, 'recall': 0.3, 'f1': 0.3, 'nDCG': 0.672, 'mRR': 1.0}\n",
+      "Category: objects_with_count, Method: threshold=0.3\n",
+      "{'precision': 0.315, 'recall': 0.3, 'f1': 0.303, 'nDCG': 0.656, 'mRR': 0.845}\n",
+      "Category: reasoning, Method: k=10\n",
+      "{'precision': 0.34, 'recall': 0.34, 'f1': 0.34, 'nDCG': 0.574, 'mRR': 1.0}\n",
+      "Category: reasoning, Method: threshold=0.3\n",
+      "{'precision': 0.361, 'recall': 0.277, 'f1': 0.297, 'nDCG': 0.551, 'mRR': 0.793}\n",
+      "Category: text_on_image, Method: k=10\n",
+      "{'precision': 0.58, 'recall': 0.58, 'f1': 0.58, 'nDCG': 0.697, 'mRR': 1.0}\n",
+      "Category: text_on_image, Method: threshold=0.3\n",
+      "{'precision': 0.482, 'recall': 0.613, 'f1': 0.498, 'nDCG': 0.641, 'mRR': 0.736}\n",
+      "Index created with 500 sentences\n",
+      "Index created with 500 sentences\n",
+      "Option random\n",
+      "Category: object, Method: k=10\n",
+      "{'precision': 0.52, 'recall': 0.52, 'f1': 0.52, 'nDCG': 0.53, 'mRR': 1.0}\n",
+      "Category: object, Method: threshold=0.3\n",
+      "{'precision': 0.534, 'recall': 0.523, 'f1': 0.519, 'nDCG': 0.631, 'mRR': 0.945}\n",
+      "Category: action, Method: k=10\n",
+      "{'precision': 0.38, 'recall': 0.38, 'f1': 0.38, 'nDCG': 0.677, 'mRR': 1.0}\n",
+      "Category: action, Method: threshold=0.3\n",
+      "{'precision': 0.425, 'recall': 0.37, 'f1': 0.391, 'nDCG': 0.723, 'mRR': 1.0}\n",
+      "Category: objects_with_count, Method: k=10\n",
+      "{'precision': 0.3, 'recall': 0.3, 'f1': 0.3, 'nDCG': 0.592, 'mRR': 1.0}\n",
+      "Category: objects_with_count, Method: threshold=0.3\n",
+      "{'precision': 0.31, 'recall': 0.297, 'f1': 0.302, 'nDCG': 0.56, 'mRR': 0.874}\n",
+      "Category: reasoning, Method: k=10\n",
+      "{'precision': 0.34, 'recall': 0.34, 'f1': 0.34, 'nDCG': 0.613, 'mRR': 1.0}\n",
+      "Category: reasoning, Method: threshold=0.3\n",
+      "{'precision': 0.316, 'recall': 0.296, 'f1': 0.302, 'nDCG': 0.497, 'mRR': 0.791}\n",
+      "Category: text_on_image, Method: k=10\n",
+      "{'precision': 0.52, 'recall': 0.52, 'f1': 0.52, 'nDCG': 0.764, 'mRR': 1.0}\n",
+      "Category: text_on_image, Method: threshold=0.3\n",
+      "{'precision': 0.48, 'recall': 0.553, 'f1': 0.51, 'nDCG': 0.691, 'mRR': 0.796}\n"
+     ]
+    }
+   ],
+   "source": [
+    "for option in options_without_all:\n",
+    "    truth_image_reps = ImageRepresentations(filenames=list(git_predicted_file.keys()),\n",
+    "                                                            representations=get_aggregated_caption_list(coco_object, option, filenames), \n",
+    "                                                            url_prefix=url_prefix)\n",
+    "    truth_ss_k = SearchService(image_representations=truth_image_reps, encoder_model=encoder_model, k=10)\n",
+    "    truth_ss_thresh = SearchService(image_representations=truth_image_reps, encoder_model=encoder_model, threshold=0.3)\n",
+    "    print(\"Option\", option)\n",
+    "    for category in all_queries[\"categories\"].keys():\n",
+    "        query_group = all_queries[\"categories\"][category]\n",
+    "\n",
+    "        # try with k \n",
+    "        performance_dict = {\"precision\": [], \"recall\": [], \"f1\": [], \"nDCG\": [], \"mRR\": []}\n",
+    "        print(\"Category: %s, Method: k=10\" % (category))\n",
+    "        for query in query_group:\n",
+    "            retrieved_files = git_ss_k.search(query)\n",
+    "            true_retrieved_files = truth_ss_k.search(query)\n",
+    "            performance_dict = get_scores(retrieved_files, true_retrieved_files, performance_dict)\n",
+    "        avg_performance_dict = {k: sum(v) / len(v) for k, v in performance_dict.items()}\n",
+    "        # round all values to 3 decimal places\n",
+    "        avg_performance_dict = {k: round(v, 3) for k, v in avg_performance_dict.items()}\n",
+    "        print(avg_performance_dict)\n",
+    "        \n",
+    "        # try with threshold\n",
+    "        for query in query_group:\n",
+    "            retrieved_files = git_ss_thresh.search(query)\n",
+    "            true_retrieved_files = truth_ss_thresh.search(query)\n",
+    "            performance_dict = get_scores(retrieved_files, true_retrieved_files, performance_dict)\n",
+    "        avg_performance_dict = {k: sum(v) / len(v) for k, v in performance_dict.items()}\n",
+    "        # round all values to 3 decimal places\n",
+    "        avg_performance_dict = {k: round(v, 3) for k, v in avg_performance_dict.items()}\n",
+    "        print(\"Category: %s, Method: threshold=0.3\" % (category))\n",
+    "        print(avg_performance_dict)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##### CONTENTS FROM EMRAH'S SCRIPT IN CLIP_SEARCH.PY #####\n",
+    "def prep_dataset_and_index(model_name, batch_size, option):\n",
+    "    print(\"loading coco...\")\n",
+    "    coco_dataset = load_cocos_like_dataset_in_range(5, model_name,  last_index=last_index,  option=option)\n",
+    "    print(\"creating embedding service...\")\n",
+    "    embedding_service = EmbeddingService(model_name, coco_dataset, \"mscoco\")\n",
+    "    print(\"start embedding %s images...\" % len(coco_dataset))\n",
+    "    index, text_embeddings = embedding_service.get_embeddings(batch_size)\n",
+    "    # i just learned how to use functions of subsets of datasets so i kept it :D\n",
+    "    print(\"first image's filename:\",coco_dataset.dataset.get_filename(0))\n",
+    "    print(text_embeddings[0].shape)\n",
+    "    \n",
+    "    return index, text_embeddings, coco_dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index, text_embeddings, coco_dataset = prep_dataset_and_index(model_name, batch_size, options[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def embed_query(query, encoder_model):\n",
+    "    # encode the query\n",
+    "    embedded_query = encoder_model.encode(query, convert_to_tensor=True)\n",
+    "    # normalize the query\n",
+    "    embedded_query = embedded_query / embedded_query.norm(dim=-1, keepdim=True)\n",
+    "    return embedded_query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"cake\"\n",
+    "\n",
+    "embedded_query = embed_query(query, encoder_model)\n",
+    "print(embedded_query.shape)\n",
+    "\n",
+    "# search for the query\n",
+    "# D, I = index.search(embedded_query, k)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "image-search",
+   "language": "python",
+   "name": "image-search"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
coco_experiment_index.ipynb uses the index and reports the first, concat, random methods.

coco_experiment_all.ipynb loads my presaved embeddings for coco first 500 embeddings for ground truth and git captions, then calculates average embedding, highest singular similarity score embedding and average similarity score embedding methods.