### PR TITLE
demo improvements

### DIFF
--- a/src/demo/app_v2.py
+++ b/src/demo/app_v2.py
@@ -1,0 +1,108 @@
+# run python app.py or gradio app.py (to reload the app on changes automatically)
+
+import gradio as gr
+from sentence_transformers import SentenceTransformer
+import json
+import os
+import sys
+
+sys.path.append("../")
+sys.path.append(".")
+
+from services.data_utilizer import DataUtilizer
+from demo.clip import get_text_embedding
+from data.coco import create_gt_captions_dict
+from services.search import ImageRepresentations, SearchService
+from services.settings import settings
+from demo.utils import format_score
+
+coco_path = os.path.join(settings.data_dir, "coco/images/val2017/")
+
+k_default = 10
+mode = "random"
+
+# LLAVA
+llava_caption_path = os.path.join(settings.output_dir, "response_dict.json") # format-> filename:caption
+llava_predicted_file = json.load(open(llava_caption_path))
+
+llava_image_representions = ImageRepresentations(filenames=list(llava_predicted_file.keys()), representations=list(llava_predicted_file.values()), url_prefix="http://images.cocodataset.org/val2017/")
+encoder_model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2', cache_folder=settings.models_cache_dir)
+
+llava_ss = SearchService(image_representations=llava_image_representions, encoder_model=encoder_model, k=k_default) #threshold=0.3
+
+# GIT
+git_caption_path = os.path.join(settings.output_dir, "response_dict_git_500.json") 
+git_predicted_file = json.load(open(git_caption_path))
+git_image_representions = ImageRepresentations(filenames=list(git_predicted_file.keys()), representations=list(git_predicted_file.values()), url_prefix="http://images.cocodataset.org/val2017/")
+git_ss = SearchService(image_representations=git_image_representions, encoder_model=encoder_model, k=k_default)
+
+# define another search service i.e for CLIP, change image representations
+clip_root = "/storage/group/dataset_mirrors/old_common_datasets/coco2017/coco_val17/val2017"
+clip_image_path = os.path.join(settings.output_dir, "image_mscoco_CLIP_500_first.pth")
+data_util = DataUtilizer("")
+clip_image_repr = data_util.load_texts_embeddings(clip_image_path).cpu()
+clip_filename_path = os.path.join(settings.output_dir, "filenames_clip.json")
+clip_filenames = data_util.load_json_file(clip_filename_path)
+clip_image_representations = ImageRepresentations(clip_filenames, clip_image_repr, url_prefix="http://images.cocodataset.org/val2017/")
+
+clip_ss = SearchService(image_representations=clip_image_representations, k=k_default)
+
+# COCO captions as Ground truth
+gt_dict = create_gt_captions_dict(llava_image_representions.get_filenames(), mode) # TODO: get filenames from somewhere else
+gt_image_captions = ImageRepresentations(list(gt_dict.keys()), list(gt_dict.values()), url_prefix="http://images.cocodataset.org/val2017/")
+gt_ss = SearchService(gt_image_captions, encoder_model, k=k_default)
+
+# We can customize this function to use different models
+def llava_search(query, k, threshold):
+    retrieved_files, captions, scores = llava_ss.search_and_caption(query, k, threshold, return_url=False)
+    return [(os.path.join(coco_path, file), format_score(score)+" "+caption) for file, caption, score in zip(retrieved_files, captions, scores)]
+
+def git_search(query, k, threshold):
+    retrieved_files, captions, scores = git_ss.search_and_caption(query, k, threshold, return_url=False)
+    return [(os.path.join(coco_path, file), format_score(score)+" "+caption) for file, caption, score in zip(retrieved_files, captions, scores)]
+
+def clip_search(query, k, threshold):
+    retrieved_files, scores = clip_ss.search_and_score(get_text_embedding([query]), k, threshold, return_url=False)
+    return [(os.path.join(clip_root, file), format_score(score)) for file, score in zip(retrieved_files, scores)] # No captions for this option
+
+def gt_search(query, k, threshold):
+    retrieved_files, captions, scores = gt_ss.search_and_caption(query, k, threshold, return_url=False)
+    return [(os.path.join(coco_path, file), format_score(score)+" "+caption) for file, caption, score in zip(retrieved_files, captions, scores)]
+
+def search(model_name, query, k, threshold):
+    if model_name == "LLaVa":
+        return llava_search(query, k, threshold)
+    elif model_name == "CLIP":
+        return clip_search(query, k, threshold)
+    elif model_name == "GIT":
+        return git_search(query, k, threshold)
+    elif model_name == "Ground Truth":
+        return gt_search(query, k, threshold)
+
+k, threshold = None, None
+
+with gr.Blocks() as demo:
+    with gr.Row():
+        with gr.Column(scale=1):
+            model_choices = gr.CheckboxGroup(choices=["LLaVa", "CLIP", "GIT", "Ground Truth"], label="Select models")
+            query = gr.Textbox(label="Enter your query here")
+
+            submit_button = gr.Button("Submit")
+            
+            
+        @gr.render(inputs=[model_choices, query], triggers=[submit_button.click])
+        def show(model_choices, query):
+            with gr.Column(scale=2):
+                for choice in model_choices:
+                    results = search(choice, query, k, threshold)
+                    gr.Markdown(
+                        f"""
+                        \n# {choice} results\n
+                        """
+                    )
+                    gr.Gallery(value=results, columns=4, label=f"Retrieved images from {choice}", show_label=True)
+
+
+# Run the interface
+demo.launch()
+

--- a/src/demo/utils.py
+++ b/src/demo/utils.py
@@ -1,0 +1,2 @@
+def format_score(score):
+    return "{:.2f}".format(score)

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -110,10 +110,29 @@ class SearchService:
         else:
             return self.image_representations.get_filenames(I)
 
-    def search_and_caption(self, query: str, return_url: bool = False) -> List[str]:
-        D, I = self.faiss_service.search_index(query, self.k, self.threshold)
+    def search_and_score(self, query: str, k: int = None, threshold: float = None, return_url: bool = False) -> List[str]:
+        if k is None:
+            k = self.k
+        if threshold is None:
+            threshold = self.threshold
+        
+        D, I = self.faiss_service.search_index(query, k, threshold)
         
         if return_url:
-            return self.image_representations.get_urls(I), self.image_representations.get_representations(I)
+            return self.image_representations.get_urls(I), D
         else:
-            return self.image_representations.get_filenames(I), self.image_representations.get_representations(I)
+            return self.image_representations.get_filenames(I), D
+
+
+    def search_and_caption(self, query: str, k: int = None, threshold: float = None, return_url: bool = False) -> List[str]:
+        if k is None:
+            k = self.k
+        if threshold is None:
+            threshold = self.threshold
+        
+        D, I = self.faiss_service.search_index(query, k, threshold)
+        
+        if return_url:
+            return self.image_representations.get_urls(I), self.image_representations.get_representations(I), D
+        else:
+            return self.image_representations.get_filenames(I), self.image_representations.get_representations(I), D

--- a/src/services/settings.py
+++ b/src/services/settings.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     data_dir: str
     output_dir: str
     log_dir: str
+    models_cache_dir: str
     
 load_dotenv()
 settings = Settings()


### PR DESCRIPTION
Ground truth search
Separate result sets are implemented for each way + ground truth, displayed depending on user input
Score probability included to captions

**Added new search functions to SearchService to enable receiving, k and threshold. Didn't modify existing ones to avoid breaking existing scripts.**

IMPORTANT:
Add the line below to your .env file
`MODELS_CACHE_DIR="${PROJECT_ROOT_DIR}/models/"`

Couldn't figure out a way to include k and threshold selection for user. I hope one of you finds time to check it out and implement.

Logic should be:
if topK search -> then please set k to a gr.Number, set threshold to None (threshold being none is important)
if threshold search -> then set threshold to gr.Slider, set k to None